### PR TITLE
Fix: main area width should be auto (fix #4)

### DIFF
--- a/override.css
+++ b/override.css
@@ -140,3 +140,7 @@ div[aria-label="New Tweets are available. Push period to go to the beginning of 
 article[data-testid="tweetDetail"] > div:first-child {
   display: none;
 }
+
+main[role="main"] > div {
+  width: auto;
+}

--- a/override.css
+++ b/override.css
@@ -142,5 +142,5 @@ article[data-testid="tweetDetail"] > div:first-child {
 }
 
 main[role="main"] > div {
-  width: auto;
+  width: 900px;
 }


### PR DESCRIPTION
As described in #4, on smaller screens the sidebar navigation is partially pushed off-screen because both the sidebar and main content area have fixe widths that total for more than 1280 px.

Overriding the main content area's `width` to be sligtly smaller (`900px` instead of `990`) is enought to fix this on common screens.

![image](https://user-images.githubusercontent.com/1444526/65721948-734d8380-e0ab-11e9-81f7-c03c2f01e675.png)

close #4