### PR TITLE
[update] override.css

### DIFF
--- a/override.css
+++ b/override.css
@@ -154,3 +154,9 @@ main[role="main"] > div {
 div[data-testid="DMDrawer"] {
   visibility: hidden
 }
+
+header[role="banner"] div[role="presentation"] div:last-child {  
+  /* fix avatar picture */
+  width: 40px;
+  height: 40px;
+} 


### PR DESCRIPTION
fix avatar picture in sidebar

Now it is really fixed.
Before the tabs were also affected by the new css rule.

![Bildschirmfoto 2021-02-01 um 02 56 56](https://user-images.githubusercontent.com/3305254/106406691-60cf2100-643a-11eb-9276-3d2dd507753a.png)

![Bildschirmfoto 2021-02-01 um 03 03 38](https://user-images.githubusercontent.com/3305254/106406688-5d3b9a00-643a-11eb-8449-7e67e3a6f100.png)
