### PR TITLE
Current version is not working

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Productive Twitter",
   "version": "1.0.2",
 
@@ -14,7 +14,7 @@
     }
   ],
 
-  "page_action": {
+  "action": {
     "default_icon": {
       "16": "icons/icon16.png",
       "32": "icons/icon32.png"


### PR DESCRIPTION
As per chrome guildlines V2 will not be supported by 2023 and while launching it was throwing an error "Manifest version 2 is deprecated, and support will be removed in 2023. See https://developer.chrome.com/blog/mv2-transition/ for more details."

so migrated it to v3 . Feel free to check out 🙂